### PR TITLE
Fix writeGenerator XML error

### DIFF
--- a/lib/atom-writer.js
+++ b/lib/atom-writer.js
@@ -234,14 +234,14 @@ ATOMWriter.prototype = {
   writeGenerator: function (value, version, uri) {
     assert.equal(typeof value, 'string')
     this.writer.startElement('generator');
-    if (typeof value === 'string') {
-      this.writer.text(value)
-    }
     if (typeof version === 'string') {
       this.writer.writeAttribute('version', version)
     }
     if (typeof uri === 'string') {
       this.writer.writeAttribute('uri', uri)
+    }
+    if (typeof value === 'string') {
+      this.writer.text(value)
     }
     this.writer.endElement()
     return this

--- a/test/basic.js
+++ b/test/basic.js
@@ -15,6 +15,7 @@ exports['t01'] = function (test) {
 
   this.aw
   .startFeed('urn:tps:com-idx', updated, created)
+  .writeGenerator('Generator', '1.0', 'http://example.net/')
   .writeStartIndex(1)
   .writeItemsPerPage(10)
   .writeTotalResults(100)
@@ -42,6 +43,6 @@ exports['t01'] = function (test) {
   this.aw
   .endFeed()
   //console.log(this.xw.toString())
-  test.equal(this.xw.toString(), '<feed xmlns="http://www.w3.org/2005/Atom" xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/"><id>urn:tps:com-idx</id><created>1971-01-01T00:00:00Z</created><updated>1971-01-01T00:00:00Z</updated><opensearch:startIndex>1</opensearch:startIndex><opensearch:itemsPerPage>10</opensearch:itemsPerPage><opensearch:totalResults>100</opensearch:totalResults><title type="text">Index of /</title><link type="application/atom+xml" href="http://exemple.com/feed.xml" rel="self"/><entry><id>urn:tps:com-idx-1</id><updated>1971-01-01T00:00:00Z</updated><published>1971-01-01T00:00:00Z</published><title type="text">Data 1</title><link type="text/xml" href="/1.xml"/><link type="text/plain" href="/1.txt"/><content type="text" xml:lang="fr">Un</content><author><name>Tata Toto</name><email>toto@exemple.com</email></author><category term="term" scheme="http://exemple.com#scheme"/></entry><entry><id>urn:tps:com-idx-2</id><updated>1971-01-01T00:00:00Z</updated><published>1971-01-01T00:00:00Z</published><title type="text">Data 2</title><link type="text/plain" href="2.txt"/><content type="text" xml:lang="fr">deux</content><author><name>titi.toto</name><email>titi.toto@exemple.com</email></author></entry></feed>')
+  test.equal(this.xw.toString(), '<feed xmlns="http://www.w3.org/2005/Atom" xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/"><id>urn:tps:com-idx</id><created>1971-01-01T00:00:00Z</created><updated>1971-01-01T00:00:00Z</updated><generator version="1.0" uri="http://example.net/">Generator</generator><opensearch:startIndex>1</opensearch:startIndex><opensearch:itemsPerPage>10</opensearch:itemsPerPage><opensearch:totalResults>100</opensearch:totalResults><title type="text">Index of /</title><link type="application/atom+xml" href="http://exemple.com/feed.xml" rel="self"/><entry><id>urn:tps:com-idx-1</id><updated>1971-01-01T00:00:00Z</updated><published>1971-01-01T00:00:00Z</published><title type="text">Data 1</title><link type="text/xml" href="/1.xml"/><link type="text/plain" href="/1.txt"/><content type="text" xml:lang="fr">Un</content><author><name>Tata Toto</name><email>toto@exemple.com</email></author><category term="term" scheme="http://exemple.com#scheme"/></entry><entry><id>urn:tps:com-idx-2</id><updated>1971-01-01T00:00:00Z</updated><published>1971-01-01T00:00:00Z</published><title type="text">Data 2</title><link type="text/plain" href="2.txt"/><content type="text" xml:lang="fr">deux</content><author><name>titi.toto</name><email>titi.toto@exemple.com</email></author></entry></feed>')
   test.done()
 };


### PR DESCRIPTION
One must write XML attributes before the content, otherwise attributes are appended to the content.
Add test for writeGenerator().
